### PR TITLE
Add network selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,69 +15,70 @@ import { MviIndexComponentsProvider } from 'contexts/MviIndexComponents'
 import { BedIndexComponentsProvider } from 'contexts/BedIndexComponents'
 import { DataIndexComponentsProvider } from 'contexts/DataIndexComponents'
 
+import { ChainId, COIN_GECKO_CHAIN_KEY } from './utils/constants/constants'
+
 const TABS = {
   tokenLiquidity: 'Token Liquidity',
-  indexLiquidity: 'Index Liquidity'
+  indexLiquidity: 'Index Liquidity',
 }
 
 const App: React.FC = () => {
   const [desiredAmount, setDesiredAmount] = useState('')
-  const [activeTab, setActiveTab] = useState(TABS.indexLiquidity)
+  const [networkKey, setNetworkKey] = useState(COIN_GECKO_CHAIN_KEY[1])
+  const [activeTab, setActiveTab] = useState(TABS.tokenLiquidity)
   const onActiveTabChange = (e: MouseEvent): void => {
     setActiveTab(e.currentTarget.innerHTML)
   }
   const onDesiredAmountChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDesiredAmount(e.target.value)
   }
+  const onSelectedNetwork = (chainId: ChainId) => {
+    const networkKey = COIN_GECKO_CHAIN_KEY[chainId]
+    setNetworkKey(networkKey)
+  }
   const renderTokenLiquidityTab = () => {
-    return activeTab === TABS.tokenLiquidity
-      ? <>
-          <TitleHeader>
-            <TokenTitle />
-            <NetworkSelector />
-          </TitleHeader>
-          <Container>
-            <TokenSelect
-              {...props}
-            />
-            <StyledLabel>$</StyledLabel>
-            <TextField
-              value={props.desiredAmount}
-              onChange={props.onDesiredAmountChange}
-              label='Desired Amount'
-              inputProps={{
-                autoComplete: 'new-password', // disable autocomplete and autofill
-              }}
-            />
-          </Container>
-          <LiquidityTable
-            {...props}
+    return activeTab === TABS.tokenLiquidity ? (
+      <>
+        <TitleHeader>
+          <TokenTitle />
+          <NetworkSelector didSelectNetwork={onSelectedNetwork} />
+        </TitleHeader>
+        <Container>
+          <TokenSelect {...props} />
+          <StyledLabel>$</StyledLabel>
+          <TextField
+            value={props.desiredAmount}
+            onChange={props.onDesiredAmountChange}
+            label='Desired Amount'
+            inputProps={{
+              autoComplete: 'new-password', // disable autocomplete and autofill
+            }}
           />
-        </>
-      : null
+        </Container>
+        <LiquidityTable {...props} networkKey={networkKey} />
+      </>
+    ) : null
   }
   const renderIndexLiquidityTab = () => {
-    return activeTab === TABS.indexLiquidity
-      ? <>
-          <IndexLiquidityTab 
-            {...props}
-          />
-        </>
-      : null
+    return activeTab === TABS.indexLiquidity ? (
+      <>
+        <IndexLiquidityTab {...props} />
+      </>
+    ) : null
   }
   const props = {
-    desiredAmount, 
-    onDesiredAmountChange
+    desiredAmount,
+    onDesiredAmountChange,
   }
   return (
     <Providers>
       <div className='App'>
         <header className='App-header'>
-          <TabNavigator 
+          <TabNavigator
             activeTab={activeTab}
             tabs={TABS}
             onActiveTabChange={onActiveTabChange}
-          />            
+          />
           {renderTokenLiquidityTab()}
           {renderIndexLiquidityTab()}
         </header>
@@ -93,9 +94,7 @@ const Providers: React.FC = ({ children }) => {
         <BedIndexComponentsProvider>
           <DataIndexComponentsProvider>
             <TokenProvider>
-              <PricesProvider>
-                {children}
-              </PricesProvider>
+              <PricesProvider>{children}</PricesProvider>
             </TokenProvider>
           </DataIndexComponentsProvider>
         </BedIndexComponentsProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import 'App.css'
 import { PricesProvider } from 'contexts/Prices'
 import { TokenProvider } from 'contexts/Token'
 import LiquidityTable from 'components/LiquidityTable'
+import NetworkSelector from 'components/NetworkSelector'
 import TokenSelect from 'components/TokenSelect'
 import TokenTitle from 'components/TokenTitle'
 import TabNavigator from 'components/TabNavigator'
@@ -31,9 +32,12 @@ const App: React.FC = () => {
   const renderTokenLiquidityTab = () => {
     return activeTab === TABS.tokenLiquidity
       ? <>
-          <TokenTitle />
+          <TitleHeader>
+            <TokenTitle />
+            <NetworkSelector />
+          </TitleHeader>
           <Container>
-            <TokenSelect 
+            <TokenSelect
               {...props}
             />
             <StyledLabel>$</StyledLabel>
@@ -112,4 +116,10 @@ const Container = styled.div`
 const StyledLabel = styled.label`
   padding-left: 15px;
   padding-right: 5px;
+`
+
+const TitleHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: left;
 `

--- a/src/components/LiquidityTable.tsx
+++ b/src/components/LiquidityTable.tsx
@@ -8,13 +8,14 @@ import { PRICE_DECIMALS, EXCHANGES } from 'utils/constants/constants'
 
 const LiquidityTable = (props: {
   desiredAmount: string
+  networkKey: string
 }) => {
   const [tokenPrice, setTokenPrice] = useState<BigNumber>(BigNumber.from(0))
   const { selectedToken } = useContext(TokenContext)
 
   // get token price in USD
   useEffect(() => {
-    fetch(getCoinGeckoApi(selectedToken.address))
+    fetch(getCoinGeckoApi(selectedToken.address, props.networkKey))
       .then((response) => response.json())
       .then((response) => {
         setTokenPrice(
@@ -24,7 +25,7 @@ const LiquidityTable = (props: {
         )
       })
       .catch((error) => console.log(error))
-  }, [selectedToken.address])
+  }, [selectedToken.address, props.networkKey])
 
   return (
     <DataTableContainer>

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -13,7 +13,7 @@ const defaultChainId = 1
 
 const selectableNetworks: Network[] = [
   { chainId: ChainId.ethereum, label: 'Mainnet' },
-  { chainId: ChainId.polygon, label: 'Polygon' },
+  // { chainId: ChainId.polygon, label: 'Polygon' },
 ]
 
 interface NetworkSelectorProps {

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -1,27 +1,30 @@
 import { useState } from 'react'
 import styled from 'styled-components'
 
+import { ChainId } from '../utils/constants/constants'
+
 interface Network {
   chainId: number
-  key: string
   label: string
 }
 
 // Default chain is Ethereum Mainnet
 const defaultChainId = 1
 
-// TODO: add keys and ids to constants?
 const selectableNetworks: Network[] = [
-  { chainId: 1, key: 'ethereum', label: 'Mainnet' },
-  { chainId: 137, key: 'polygon-pos', label: 'Polygon' },
+  { chainId: ChainId.ethereum, label: 'Mainnet' },
+  { chainId: ChainId.polygon, label: 'Polygon' },
 ]
 
-export default function NetworkSelector() {
+interface NetworkSelectorProps {
+  didSelectNetwork: (chainId: ChainId) => void
+}
+
+export default function NetworkSelector(props: NetworkSelectorProps) {
   const [selectedChainId, setSelectedChainId] = useState(defaultChainId)
 
-  const selectChain = (chainId: number) => {
-    // TODO: notify provider??
-    console.log(chainId)
+  const selectChain = (chainId: ChainId) => {
+    props.didSelectNetwork(chainId)
     setSelectedChainId(chainId)
   }
 
@@ -30,7 +33,7 @@ export default function NetworkSelector() {
       {selectableNetworks.map((network) => {
         return (
           <NetworkButtonToggle
-            key={network.key}
+            key={network.chainId}
             active={network.chainId === selectedChainId}
             onClick={() => selectChain(network.chainId)}
           >

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+
+interface Network {
+  chainId: number
+  key: string
+  label: string
+}
+
+// Default chain is Ethereum Mainnet
+const defaultChainId = 1
+
+// TODO: add keys and ids to constants?
+const selectableNetworks: Network[] = [
+  { chainId: 1, key: 'ethereum', label: 'Mainnet' },
+  { chainId: 137, key: 'polygon-pos', label: 'Polygon' },
+]
+
+export default function NetworkSelector() {
+  const [selectedChainId, setSelectedChainId] = useState(defaultChainId)
+
+  const selectChain = (chainId: number) => {
+    // TODO: notify provider??
+    console.log(chainId)
+    setSelectedChainId(chainId)
+  }
+
+  return (
+    <ButtonGroup>
+      {selectableNetworks.map((network) => {
+        return (
+          <NetworkButtonToggle
+            key={network.key}
+            active={network.chainId === selectedChainId}
+            onClick={() => selectChain(network.chainId)}
+          >
+            {network.label}
+          </NetworkButtonToggle>
+        )
+      })}
+    </ButtonGroup>
+  )
+}
+
+const ButtonGroup = styled.div`
+  display: flex;
+  margin-left: 32px;
+`
+
+const NetworkButton = styled.button`
+  background: rgba(100, 100, 200, 0.2);
+  border: 0px;
+  border-radius: 20px;
+  color: #333;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 10px 16px;
+  margin: 0 2px;
+`
+
+const NetworkButtonToggle = styled(NetworkButton)<{ active: boolean }>`
+  background: #fff;
+  ${({ active }) =>
+    active &&
+    `
+    background: rgba(100, 100, 200, 0.2);
+  `}
+`

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -45,8 +45,11 @@ export const ALCHEMY_API =
   'https://eth-mainnet.alchemyapi.io/v2/5j2PCDrDSbB5C6n8pnka21H3NSoUje4j' // + process.env.ALCHEMY_TOKEN;
 
 export const CG_ETH_PRICE_URL = `https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd`
-export const getCoinGeckoApi = (tokenAddress: string) => {
-  return `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`
+export const getCoinGeckoApi = (
+  tokenAddress: string,
+  networkKey: string = 'ethereum'
+) => {
+  return `https://api.coingecko.com/api/v3/simple/token_price/${networkKey}?contract_addresses=${tokenAddress}&vs_currencies=usd`
 }
 
 export const UNI_V2_FACTORY = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -3,6 +3,16 @@ import { ExchangeName } from 'utils/poolData'
 
 const { AddressZero, MaxUint256, One, Two, Zero } = constants
 
+export enum ChainId {
+  ethereum = 1,
+  polygon = 137,
+}
+
+export const COIN_GECKO_CHAIN_KEY = {
+  [ChainId.ethereum]: 'ethereum',
+  [ChainId.polygon]: 'polygon-pos',
+}
+
 export const ADDRESS_ZERO = AddressZero
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 export const EMPTY_BYTES = '0x'


### PR DESCRIPTION
## Description
Adds a network selector to switch networks (for now Ethereum and Polygon). [Ticket](https://www.notion.so/index-coop/2d52bfda476e4f92be79aee3f42d804d?v=b1f2ff9e7c1f44e3a27b7043209822f6&p=c36fb96353944322ab5b6a5d62db00c4)

Based on https://github.com/IndexCoop/liquidity-analyzer/pull/11 because I saw there were quite some changes in areas I would also touch. ✅ 

Actually switching networks will be done in a separate PR. 💡 

## UI
- [x] I took a simpler more convenient approach for the UI (see screenshot). Let me know if that's ok?
<img width="1292" alt="Bildschirmfoto 2021-11-15 um 11 16 06" src="https://user-images.githubusercontent.com/2104965/141765895-ad398de1-f72e-4443-93ec-5a81501c5a36.png">

