### PR TITLE
Add balancer v2 (polygon)

### DIFF
--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -10,7 +10,7 @@ interface Network {
 
 const selectableNetworks: Network[] = [
   { chainId: ChainId.ethereum, label: 'Mainnet' },
-  // { chainId: ChainId.polygon, label: 'Polygon' },
+  { chainId: ChainId.polygon, label: 'Polygon' },
 ]
 
 interface NetworkSelectorProps {


### PR DESCRIPTION
## Description
Adds the missing balancer v2 integration to complete the polygon feature. [The graph ](https://thegraph.com/hosted-service/subgraph/balancer-labs/balancer-polygon-v2) is used to fetch data for balancer v2.

## Testing
There is not many WETH pairs on balancer. You can check a full list [here](https://polygon.balancer.fi/).
* USDC
* WBTC
* WMATIC
* BAL

❗sometimes the fetched eth price is 0 and thus won't show the correct liquidity. Then the displayed liquidity should be half of what is shown on balancer (as most pools are 50-50 weighted).