### PR TITLE
Remove unused 0x exchange from index liquidity

### DIFF
--- a/src/components/IndexLiquidityTab/IndexLiquidityDataTableRow.tsx
+++ b/src/components/IndexLiquidityTab/IndexLiquidityDataTableRow.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { ChangeEvent, useState, useEffect } from 'react'
 import TextField from '@mui/material/TextField'
 import IndexComponent from 'components/IndexComponent'
-import { ChainId, PRICE_DECIMALS, EXCHANGES } from 'utils/constants/constants'
+import { ChainId, PRICE_DECIMALS, REBALANCE_EXCHANGES } from 'utils/constants/constants'
 import { getMaxTrade, ExchangeName } from 'utils/poolData'
 import { BigNumber } from 'ethers'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -60,7 +60,7 @@ const IndexLiquidityDataTableRow = (props: props) => {
   }
   const findMaxTrade = async (component: IndexComponent) => {
     const checkExchanges = async () => Promise.all(
-      EXCHANGES.map((exchange) => checkMaxTrade(exchange, component)
+      REBALANCE_EXCHANGES.map((exchange) => checkMaxTrade(exchange, component)
         .then((response) => {
           return {
             exchange,

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -47,6 +47,9 @@ export const DPI_SINGLE_INDEX_MODULE =
 export const TEN_POW_18 = BigNumber.from(10).pow(18)
 export const TEN_POW_16 = BigNumber.from(10).pow(16)
 
+// Choose how many decimals to keep when converting float price to BigNumber
+export const PRICE_DECIMALS = 100
+
 export const ALCHEMY_API = {
   [ChainId.ethereum]: `https://eth-mainnet.alchemyapi.io/v2/${process.env.REACT_APP_ALCHEMY_API_ETHEREUM}`,
   [ChainId.polygon]: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_API_POLYGON}`,
@@ -99,6 +102,9 @@ export const EXCHANGES: Array<ExchangeName> = [
   'Balancer',
   'ZeroEx',
 ]
+
+// Exchanges used for rebalances
+export const REBALANCE_EXCHANGES: Array<ExchangeName> = EXCHANGES.filter(ex => ex !== 'ZeroEx')
 
 export const V2_FACTORY_ABI = [
   {
@@ -1497,6 +1503,3 @@ export const BALANCER_OCR_ABI = [
     type: 'function',
   },
 ]
-
-// Choose how many decimals to keep when converting float price to BigNumber
-export const PRICE_DECIMALS = 100


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

Removed `ZeroEx` from the this list of exchange we query for the `Index Liquidity` tab. This exchange is not set up for rebalances and therefore not required.

No changes to the `Token Liquidity` tab. ZeroEx is still one of the exchanges.

&nbsp;

### **Fixes: https://www.notion.so/index-coop/Liquidity-Analyzer-Exclude-0x-from-Index-Liquidity-Tab-c100a220677e445ea04887a25b826f60

### Tested locally and on fleek preview

<img width="1440" alt="Screen Shot 2021-12-17 at 11 45 41 PM" src="https://user-images.githubusercontent.com/13758946/146633736-88e91e94-c42e-476f-9293-33abc42f4435.png">

