### PR TITLE
Add token lookup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const App: React.FC = () => {
     return activeTab === TABS.tokenLiquidity ? (
       <>
         <TitleHeader>
-          <TokenTitle />
+          <TokenTitle chainId={props.chainId} />
           <NetworkSelector didSelectNetwork={onSelectedNetwork} />
         </TitleHeader>
         <Container>
@@ -83,11 +83,8 @@ const App: React.FC = () => {
 }
 
 const Providers: React.FC = ({ children }) => {
-  return (
-        <MarketDataProvider>{children}</MarketDataProvider>
-  )
+  return <MarketDataProvider>{children}</MarketDataProvider>
 }
-
 
 export default App
 

--- a/src/components/ExchangeSummary.tsx
+++ b/src/components/ExchangeSummary.tsx
@@ -7,6 +7,7 @@ import { ChainId, PRICE_DECIMALS } from '../utils/constants/constants'
 import CircularProgress from '@mui/material/CircularProgress'
 import { MarketDataContext } from 'contexts/MarketData'
 import { formatDisplay, formatUSD } from 'utils/formatters'
+import { getBlockExplorerUrl } from '../utils/block-explorer'
 
 const HALF_PERCENT = 0.5
 const ONE_PERCENT = 1
@@ -17,6 +18,7 @@ const ExchangeSummary = (props: {
   desiredAmount: string
   chainId: ChainId
 }) => {
+  const [pairAddress, setPairAddress] = useState('')
   const [tokenBalance, setTokenBalance] = useState<BigNumber>(BigNumber.from(0))
   const [wethBalance, setWethBalance] = useState<BigNumber>(BigNumber.from(0))
   const [maxTrade, setMaxTrade] = useState<BigNumber>(BigNumber.from(0))
@@ -30,11 +32,17 @@ const ExchangeSummary = (props: {
   const [tradeError, setTradeError] = useState(false)
   const { selectedToken } = useContext(MarketDataContext)
   const tenPowDecimals = BigNumber.from(10).pow(selectedToken.decimals)
+  const explorerUrl =
+    pairAddress.length > 0
+      ? getBlockExplorerUrl(pairAddress, props.chainId)
+      : '#'
+  const explorerTarget = explorerUrl === '#' ? '_self' : '_blank'
 
   useEffect(() => {
     setLiquidityLoading(true)
     getLiquidity(selectedToken.address, props.exchange, props.chainId)
       .then((response) => {
+        setPairAddress(response.pairAddress)
         setTokenBalance(response.tokenBalance)
         setWethBalance(response.wethBalance)
         setLiquidityError(false)
@@ -119,7 +127,16 @@ const ExchangeSummary = (props: {
   }
   return (
     <>
-      <TableData>{props.exchange}</TableData>
+      <TableData>
+        <a
+          href={explorerUrl}
+          style={{ color: 'black' }}
+          target={explorerTarget}
+          rel='noreferrer'
+        >
+          {props.exchange}
+        </a>
+      </TableData>
       {renderCustomTableData(
         liquidityLoading,
         formatUSD(totalLiquidity),

--- a/src/components/TokenTitle.tsx
+++ b/src/components/TokenTitle.tsx
@@ -1,8 +1,36 @@
+import styled from 'styled-components'
 import { useContext } from 'react'
 import { MarketDataContext } from 'contexts/MarketData'
+import { ChainId } from '../utils/constants/constants'
+import { getBlockExplorerUrl } from '../utils/block-explorer'
 
-export default function TokenTitle() {
-  const { selectedToken } = useContext(MarketDataContext)
-
-  return <h2>{selectedToken.symbol}</h2>
+interface TokenTitleProps {
+  chainId: ChainId
 }
+
+export default function TokenTitle(props: TokenTitleProps) {
+  const { selectedToken } = useContext(MarketDataContext)
+  const explorerUrl = getBlockExplorerUrl(selectedToken.address, props.chainId)
+
+  return (
+    <div>
+      <h2 style={{ marginBottom: 0 }}>{selectedToken.symbol}</h2>
+      <Address>
+        <a
+          href={explorerUrl}
+          style={{ color: 'gray' }}
+          target='_blank'
+          rel='noreferrer'
+        >
+          {selectedToken.address.substr(0, 8)}...
+        </a>
+      </Address>
+    </div>
+  )
+}
+
+const Address = styled.h3`
+  font-size: 12px;
+  margin-top: 0;
+  padding: 0;
+`

--- a/src/utils/block-explorer.ts
+++ b/src/utils/block-explorer.ts
@@ -1,0 +1,8 @@
+import { BLOCK_EXPLORER, ChainId } from './constants/constants'
+
+export const getBlockExplorerUrl = (
+  address: string,
+  chainId: ChainId = ChainId.ethereum
+) => {
+  return BLOCK_EXPLORER[chainId] + address
+}

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -52,6 +52,11 @@ export const ALCHEMY_API = {
   [ChainId.polygon]: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_API_POLYGON}`,
 }
 
+export const BLOCK_EXPLORER = {
+  [ChainId.ethereum]: 'https://etherscan.io/address/',
+  [ChainId.polygon]: 'https://polygonscan.com/address/',
+}
+
 export const CG_ETH_PRICE_URL = `https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd`
 export const getCoinGeckoApi = (
   tokenAddress: string,
@@ -74,21 +79,21 @@ export const ALL_INDEX_SET_HTML_REFS: any = {
   DPI: 'defipulse-index',
   MVI: 'metaverse-index',
   BED: 'bankless-bed-index',
-  DATA: 'data-economy-index'
+  DATA: 'data-economy-index',
 }
 
 export const INDEX_TOKENS = {
   DPI: 'DPI',
   MVI: 'MVI',
   BED: 'BED',
-  DATA: 'DATA'
+  DATA: 'DATA',
 }
 
 export const INDEX_TOKENS_FOR_SELECT = [
   { name: 'DPI' },
   { name: 'MVI' },
   { name: 'BED' },
-  { name: 'DATA' }
+  { name: 'DATA' },
 ]
 
 export const EXCHANGES: Array<ExchangeName> = [

--- a/src/utils/poolData/balancerV1.ts
+++ b/src/utils/poolData/balancerV1.ts
@@ -28,6 +28,7 @@ const reducer = (previousValue: BigNumber, currentValue: BigNumber) =>
 // we have so put in a number that is net of fees.
 async function getBalancerV1(tokenAddress: string, chainId: ChainId) {
   let response: LiquidityBalance = {
+    pairAddress: '',
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -52,6 +53,7 @@ async function getBalancerV1(tokenAddress: string, chainId: ChainId) {
   )
 
   response = {
+    pairAddress: pools[0],
     tokenBalance: tokenBalances.reduce(reducer).div(TEN_POW_18),
     wethBalance: wethBalances.reduce(reducer).div(TEN_POW_18),
   }
@@ -61,6 +63,7 @@ async function getBalancerV1(tokenAddress: string, chainId: ChainId) {
 
 async function getBalancerV2(tokenAddress: string, chainId: ChainId) {
   let response: LiquidityBalance = {
+    pairAddress: '',
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -98,6 +101,7 @@ async function getBalancerV2(tokenAddress: string, chainId: ChainId) {
       return response
     }
 
+    let poolAddresses: string[] = []
     let tokenBalances: BigNumber[] = []
     let wethBalances: BigNumber[] = []
 
@@ -119,12 +123,14 @@ async function getBalancerV2(tokenAddress: string, chainId: ChainId) {
       } else {
         const tokenBalance = parseInt(token[0].balance)
         const wethBalance = parseInt(weth[0].balance)
+        poolAddresses.push(pool.address)
         tokenBalances.push(BigNumber.from(tokenBalance))
         wethBalances.push(BigNumber.from(wethBalance))
       }
     })
 
     response = {
+      pairAddress: poolAddresses[0],
       tokenBalance: tokenBalances.reduce(reducer),
       wethBalance: wethBalances.reduce(reducer),
     }

--- a/src/utils/poolData/kyber.ts
+++ b/src/utils/poolData/kyber.ts
@@ -25,6 +25,7 @@ export async function getKyberLiquidity(
   chainId: ChainId
 ): Promise<LiquidityBalance> {
   let response = {
+    pairAddress: '',
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -45,12 +46,12 @@ export async function getKyberLiquidity(
     const pairContract = await new Contract(pools[0], KYBER_POOL_ABI, provider)
     const [tokenBalance, wethBalance] = await pairContract.getReserves()
 
+    response.pairAddress = pairContract.address
     response.tokenBalance = tokenBalance.div(TEN_POW_18)
     response.wethBalance = tokenBalance.div(wethBalance)
-
   } catch (error) {
     console.log('Error getting liquidity from kyber')
     console.log(error)
   }
-    return response
+  return response
 }

--- a/src/utils/poolData/sushiswap.ts
+++ b/src/utils/poolData/sushiswap.ts
@@ -26,6 +26,7 @@ export async function getSushiswapLiquidity(
   chainId: ChainId
 ): Promise<LiquidityBalance> {
   let response = {
+    pairAddress: '',
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -52,6 +53,7 @@ export async function getSushiswapLiquidity(
 
     // For some reason for polygon the tokens returned seem to be switched up
     response = {
+      pairAddress,
       tokenBalance:
         chainId === ChainId.polygon
           ? wethBalance.div(TEN_POW_18)

--- a/src/utils/poolData/types.ts
+++ b/src/utils/poolData/types.ts
@@ -1,10 +1,11 @@
-import { BigNumber } from "ethers";
+import { BigNumber } from 'ethers'
 
 export type LiquidityBalance = {
-    tokenBalance: BigNumber,
-    wethBalance: BigNumber,
+  pairAddress: string
+  tokenBalance: BigNumber
+  wethBalance: BigNumber
 }
 
 export type MaxTradeResponse = {
-    size: BigNumber,
+  size: BigNumber
 }

--- a/src/utils/poolData/uniswapV2.ts
+++ b/src/utils/poolData/uniswapV2.ts
@@ -29,6 +29,7 @@ export async function getUniswapV2Liquidity(
   const [tokenBalance, wethBalance] = await pairContract.getReserves()
 
   return {
+    pairAddress,
     tokenBalance: tokenBalance.div(TEN_POW_18),
     wethBalance: wethBalance.div(TEN_POW_18),
   }

--- a/src/utils/poolData/uniswapV3.ts
+++ b/src/utils/poolData/uniswapV3.ts
@@ -35,6 +35,7 @@ export async function getUniswapV3Liquidity(
   const tokenBalance: BigNumber = await tokenContract.balanceOf(poolAddress)
   const wethBalance: BigNumber = await wethContract.balanceOf(poolAddress)
   return {
+    pairAddress: poolAddress,
     tokenBalance: tokenBalance.div(TEN_POW_18),
     wethBalance: wethBalance.div(TEN_POW_18),
   }

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -16,11 +16,14 @@ type ZeroExQuote = {
 /**
  * As a dex aggregator, it has no inherent sources of liquidity.
  */
-export async function getZeroExLiquidity(tokenAddress: string): Promise<LiquidityBalance> {
-    return {
-        tokenBalance: BigNumber.from(0),
-        wethBalance: BigNumber.from(0),
-    }
+export async function getZeroExLiquidity(
+  tokenAddress: string
+): Promise<LiquidityBalance> {
+  return {
+    pairAddress: '',
+    tokenBalance: BigNumber.from(0),
+    wethBalance: BigNumber.from(0),
+  }
 }
 
 /**


### PR DESCRIPTION
## Descriptions
Adds the functionality of looking up the selected tokens in a block explorer (depending on the selected chain). This adds the ability to quickly verify numbers showing in the table.

* Adds a subtitle to the token title that links to the selected token's address (the address is shortened to keep the layout intact)
* Adds a link to the pool's contract address to each exchange name
* If the contract address is not available, the link won't open (`#`)

## Screenshot

<img width="1328" alt="mvi" src="https://user-images.githubusercontent.com/2104965/146654704-5aa61eb7-f04e-4d92-8a0c-44967be19844.png">

