### PR TITLE
Fix sushi balance

### DIFF
--- a/src/utils/poolData/sushiswap.ts
+++ b/src/utils/poolData/sushiswap.ts
@@ -54,14 +54,8 @@ export async function getSushiswapLiquidity(
     // For some reason for polygon the tokens returned seem to be switched up
     response = {
       pairAddress,
-      tokenBalance:
-        chainId === ChainId.polygon
-          ? wethBalance.div(TEN_POW_18)
-          : tokenBalance.div(TEN_POW_18),
-      wethBalance:
-        chainId === ChainId.polygon
-          ? tokenBalance.div(TEN_POW_18)
-          : wethBalance.div(TEN_POW_18),
+      tokenBalance: tokenBalance.div(TEN_POW_18),
+      wethBalance: wethBalance.div(TEN_POW_18),
     }
   } catch (error) {
     console.log('Error getting liquidity from SushiSwap')


### PR DESCRIPTION
## Description
When originally creating the polygon feature I always had a problem of the balances being switched up. So I added this check for polygon. Probably, I just had something else mixed up back then and that's why the balances were off though. 🤦

Fixes remaining issues of [ticket](https://www.notion.so/index-coop/Liquidity-Analyzer-Number-issues-23a144b40b1a4eff87f6430a125f71d8). 

## Testing
SushiSwap balances on Polygon should now be correct. Can be checked by checking the linked contract on the block explorer (click exchange name).