### PR TITLE
Add auto switch tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@ethersproject/abstract-signer": "5.0.9",
     "@ethersproject/bignumber": "5.0.12",
     "@ethersproject/providers": "5.0.17",
+    "@indexcoop/tokenlists": "^1.2.0",
     "@mui/material": "^5.0.4",
     "@setprotocol/index-coop-contracts": "0.0.25",
     "@setprotocol/index-rebalance-utils": "^0.0.5",

--- a/src/components/TokenSelect.tsx
+++ b/src/components/TokenSelect.tsx
@@ -2,10 +2,10 @@ import Box from '@mui/material/Box'
 import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
 import { createFilterOptions } from '@mui/material/Autocomplete'
-import axios from 'axios'
+import { MainnetTokens, MaticTokens } from '@indexcoop/tokenlists'
 import { useEffect, useState, useContext, ChangeEvent } from 'react'
 import { MarketDataContext } from 'contexts/MarketData'
-import { ChainId, TOKEN_LIST } from '../utils/constants/constants'
+import { ChainId } from '../utils/constants/constants'
 
 export default function TokenSelect(props: {
   chainId: ChainId
@@ -16,13 +16,9 @@ export default function TokenSelect(props: {
   const { setSelectedToken } = useContext(MarketDataContext)
 
   useEffect(() => {
-    axios.get(TOKEN_LIST[props.chainId]).then((response) => {
-      const tokens =
-        props.chainId === ChainId.ethereum
-          ? response.data.tokens
-          : response.data
-      setTokens(tokens)
-    })
+    const tokens =
+      props.chainId === ChainId.ethereum ? MainnetTokens : MaticTokens
+    setTokens(tokens)
   }, [props.chainId])
 
   return (

--- a/src/components/TokenSelect.tsx
+++ b/src/components/TokenSelect.tsx
@@ -7,19 +7,43 @@ import { useEffect, useState, useContext, ChangeEvent } from 'react'
 import { MarketDataContext } from 'contexts/MarketData'
 import { ChainId } from '../utils/constants/constants'
 
+function getTokenDataForSymbol(tokenSymbol: string, chainId: ChainId) {
+  const tokens = chainId === ChainId.ethereum ? MainnetTokens : MaticTokens
+  const filteredTokens = tokens.filter(
+    (tokenData) => tokenData.symbol === tokenSymbol
+  )
+  return filteredTokens.length > 0 ? filteredTokens[0] : null
+}
+
 export default function TokenSelect(props: {
   chainId: ChainId
   desiredAmount: string
   onDesiredAmountChange: (arg0: ChangeEvent<HTMLInputElement>) => void
 }) {
   const [tokens, setTokens] = useState<TokenData[]>([])
-  const { setSelectedToken } = useContext(MarketDataContext)
+  const { selectedToken, setSelectedToken } = useContext(MarketDataContext)
 
   useEffect(() => {
     const tokens =
       props.chainId === ChainId.ethereum ? MainnetTokens : MaticTokens
+    const tokenData = getTokenDataForSymbol(selectedToken.symbol, props.chainId)
     setTokens(tokens)
-  }, [props.chainId])
+
+    if (tokenData === null) {
+      return
+    }
+
+    if (tokenData.address === selectedToken.address) {
+      return
+    }
+
+    setSelectedToken(tokenData)
+  }, [
+    props.chainId,
+    selectedToken.symbol,
+    selectedToken.address,
+    setSelectedToken,
+  ])
 
   return (
     <Autocomplete

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -13,12 +13,6 @@ export const COIN_GECKO_CHAIN_KEY = {
   [ChainId.polygon]: 'polygon-pos',
 }
 
-export const TOKEN_LIST = {
-  [ChainId.ethereum]: 'https://tokens.coingecko.com/uniswap/all.json',
-  [ChainId.polygon]:
-    'https://raw.githubusercontent.com/sushiswap/default-token-list/master/tokens/matic.json',
-}
-
 export const ADDRESS_ZERO = AddressZero
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 export const EMPTY_BYTES = '0x'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,11 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@indexcoop/tokenlists@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@indexcoop/tokenlists/-/tokenlists-1.2.0.tgz#10634dcf9583f29489d71b16904061eaad9b2686"
+  integrity sha512-RcCa6pAmpo1SEkeeaWqZwtwPZ46Sjvz8b39K0Ijh7siRXUFqEvag+4qQowKdMgwumpZNcdEwTuefySmwa5kL9g==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
## Description
Adds auto switching tokens when changing the chain - if the token is available on the chain that is switched to.

* Adds reading token lists from @indexcoop/tokenlists

[Ticket](https://www.notion.so/index-coop/Liquidity-Analyzer-Auto-switch-to-previously-selected-token-when-switching-chains-39003589e54b44d5ae3bc24f50ef170c)

## Testing
* Test with $MVI, $DPI or $DATA and check that the correct addresses contracts are loaded upon switching from Ethereum to Polygon or back.